### PR TITLE
fix: constrain incompatible lint upgrades

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,3 +1,21 @@
 {
-  "extends": ["github>fzf404/renovate-config"]
+  "extends": ["github>fzf404/renovate-config"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["eslint"],
+      "allowedVersions": "<10"
+    },
+    {
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
+    },
+    {
+      "matchPackageNames": ["eslint-plugin-unicorn"],
+      "allowedVersions": "<57"
+    },
+    {
+      "matchPackageNames": ["eslint-plugin-jsonc"],
+      "allowedVersions": "<3"
+    }
+  ]
 }


### PR DESCRIPTION
Pins Renovate to the last versions compatible with the repository legacy ESLint configuration. Prevents ESLint 10, TypeScript 7, Unicorn 57+, and JSONC 3+ from reopening known-broken upgrades.